### PR TITLE
Fix pubsub client use

### DIFF
--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -35,8 +35,12 @@ describe('IORedisAdapter tests', () => {
   })
 
   it('should connect to redis', async () => {
-    const client = new IORedisAdapter().client
-    const response = await client.ping()
-    expect(response).toBe('PONG')
+    const adapter = new IORedisAdapter()
+    const pub = adapter.pub
+    const sub = adapter.sub
+    const pubResponse = await pub.ping()
+    const subResponse = await sub.ping()
+    expect(pubResponse).toBe('PONG')
+    expect(subResponse).toBe('PONG')
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,16 @@ const Redis = require('ioredis')
 
 class IORedisAdapter {
   constructor(config) {
-    this.client = new Redis(config)
+    this.pub = new Redis(config)
+    this.sub = new Redis(config)
   }
 
   createPublisher() {
-    return this.client
+    return this.pub
   }
 
   createSubscriber() {
-    return this.client
+    return this.sub
   }
 }
 


### PR DESCRIPTION
Seems that redis when in sub/pub mode needs two separate clients, and if not parse-servers livequery subscriptions throw below error:
```
(node:26004) UnhandledPromiseRejectionWarning: Error: Connection in subscriber mode, only subscriber commands may be used
```

(more info here)[https://github.com/luin/ioredis#pubsub]